### PR TITLE
Update index.mjs

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -189,7 +189,7 @@ export default class Pofile {
       if (msg.plural) {
         lines.push(`msgplural ${quote(msg.plural)}`);
         let pluralStrs = arr(msg.str);
-        for (let i = 0; i < 10 || i < pluralStrs.length; i++) {
+        for (let i = 0; i < Math.min(pluralStrs.length, 10); i++) {
           lines.push(`msgstr[${i}] ${quote(pluralStrs[i])}`);
         }
       } else {


### PR DESCRIPTION
I can't spot the reason, why the plurals are limited to a maximum of 10, however it wasn't working before this fix.